### PR TITLE
UN-6

### DIFF
--- a/JavaSource/org/unitime/timetable/model/Assignment.java
+++ b/JavaSource/org/unitime/timetable/model/Assignment.java
@@ -330,11 +330,9 @@ public class Assignment extends BaseAssignment {
 	           s2+t2.getNrSlotsPerMeeting()!=s1) return false;
 	       double distance = getDistance(a1,a2);
 	       if (distance <= a1.getSolution().getProperties().getPropertyDouble("Student.DistanceLimit",67.0)) return false;
-	       if (distance <= a1.getSolution().getProperties().getPropertyDouble("Student.DistanceLimit75min",100.0) && (
+	       return !(distance <= a1.getSolution().getProperties().getPropertyDouble("Student.DistanceLimit75min",100.0) && (
 	           (t1.getLength()==18 && s1+t1.getLength()==s2) ||
 	           (t2.getLength()==18 && s2+t2.getLength()==s1)))
-	           return false;
-	       return true;
    }
 	
 	public int getMinutesPerMeeting() {


### PR DESCRIPTION
Avoid using unnecessary if-else statements when returning booleans.  


 Line 332: 

if (distance <=a1.getSolution().getProperties().getPropertyDouble("Student.DistanceLimit75min",100.0) && ((t1.getLength()==18 && s1+t1.getLength()==s2) || (t2.getLength()==18 && s2+t2.getLength()==s1)))            return false;  can simply be replaced with  boolean flag = (distance <= a1.getSolution().getProperties().getPropertyDouble("Student.DistanceLimit75min",100.0); flag = flag && (t1.getLength()==18 && s1+t1.getLength()==s2) || (t2.getLength()==18 && s2+t2.getLength()==s1); return flag; 

As simple as it is it improves the Readability, Maintainability of the method